### PR TITLE
Fix tests with Test.createTestingModule mocker and add Jest path mapping; fix React hook deps and socket cleanup

### DIFF
--- a/application/package.json
+++ b/application/package.json
@@ -82,6 +82,9 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/$1"
+    }
   }
 }

--- a/application/src/controllers/channels/channels.controller.spec.ts
+++ b/application/src/controllers/channels/channels.controller.spec.ts
@@ -7,7 +7,9 @@ describe('ChannelsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ChannelsController],
-    }).compile();
+    })
+      .useMocker(() => ({}))
+      .compile();
 
     controller = module.get<ChannelsController>(ChannelsController);
   });

--- a/application/src/controllers/conversations/conversations.controller.spec.ts
+++ b/application/src/controllers/conversations/conversations.controller.spec.ts
@@ -7,7 +7,9 @@ describe('ConversationsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ConversationsController],
-    }).compile();
+    })
+      .useMocker(() => ({}))
+      .compile();
 
     controller = module.get<ConversationsController>(ConversationsController);
   });

--- a/application/src/controllers/file-upload/file-upload.controller.spec.ts
+++ b/application/src/controllers/file-upload/file-upload.controller.spec.ts
@@ -7,7 +7,9 @@ describe('FileUploadController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [FileUploadController],
-    }).compile();
+    })
+      .useMocker(() => ({}))
+      .compile();
 
     controller = module.get<FileUploadController>(FileUploadController);
   });

--- a/application/src/controllers/friends/friends.controller.spec.ts
+++ b/application/src/controllers/friends/friends.controller.spec.ts
@@ -7,7 +7,9 @@ describe('FriendsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [FriendsController],
-    }).compile();
+    })
+      .useMocker(() => ({}))
+      .compile();
 
     controller = module.get<FriendsController>(FriendsController);
   });

--- a/application/src/controllers/invitation/invitation.controller.spec.ts
+++ b/application/src/controllers/invitation/invitation.controller.spec.ts
@@ -7,7 +7,9 @@ describe('InvitationController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [InvitationController],
-    }).compile();
+    })
+      .useMocker(() => ({}))
+      .compile();
 
     controller = module.get<InvitationController>(InvitationController);
   });

--- a/application/src/controllers/members/members.controller.spec.ts
+++ b/application/src/controllers/members/members.controller.spec.ts
@@ -7,7 +7,9 @@ describe('MembersController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [MembersController],
-    }).compile();
+    })
+      .useMocker(() => ({}))
+      .compile();
 
     controller = module.get<MembersController>(MembersController);
   });

--- a/application/src/controllers/messages/messages.controller.spec.ts
+++ b/application/src/controllers/messages/messages.controller.spec.ts
@@ -7,7 +7,9 @@ describe('MessagesController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [MessagesController],
-    }).compile();
+    })
+      .useMocker(() => ({}))
+      .compile();
 
     controller = module.get<MessagesController>(MessagesController);
   });

--- a/application/src/controllers/reactions/reactions.controller.spec.ts
+++ b/application/src/controllers/reactions/reactions.controller.spec.ts
@@ -7,7 +7,9 @@ describe('ReactionsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ReactionsController],
-    }).compile();
+    })
+      .useMocker(() => ({}))
+      .compile();
 
     controller = module.get<ReactionsController>(ReactionsController);
   });

--- a/application/src/controllers/roles/roles.controller.spec.ts
+++ b/application/src/controllers/roles/roles.controller.spec.ts
@@ -7,7 +7,9 @@ describe('RolesController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [RolesController],
-    }).compile();
+    })
+      .useMocker(() => ({}))
+      .compile();
 
     controller = module.get<RolesController>(RolesController);
   });

--- a/application/src/controllers/servers/servers.controller.spec.ts
+++ b/application/src/controllers/servers/servers.controller.spec.ts
@@ -7,7 +7,9 @@ describe('ServersController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ServersController],
-    }).compile();
+    })
+      .useMocker(() => ({}))
+      .compile();
 
     controller = module.get<ServersController>(ServersController);
   });

--- a/application/src/controllers/threads/threads.controller.spec.ts
+++ b/application/src/controllers/threads/threads.controller.spec.ts
@@ -7,7 +7,9 @@ describe('ThreadsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ThreadsController],
-    }).compile();
+    })
+      .useMocker(() => ({}))
+      .compile();
 
     controller = module.get<ThreadsController>(ThreadsController);
   });

--- a/application/src/controllers/user/user.controller.spec.ts
+++ b/application/src/controllers/user/user.controller.spec.ts
@@ -7,7 +7,9 @@ describe('UserController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UserController],
-    }).compile();
+    })
+      .useMocker(() => ({}))
+      .compile();
 
     controller = module.get<UserController>(UserController);
   });

--- a/application/src/gateway/socket/socket.gateway.spec.ts
+++ b/application/src/gateway/socket/socket.gateway.spec.ts
@@ -7,7 +7,9 @@ describe('SocketGateway', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [SocketGateway],
-    }).compile();
+    })
+      .useMocker(() => ({}))
+      .compile();
 
     gateway = module.get<SocketGateway>(SocketGateway);
   });

--- a/application/src/services/channels/channels.service.spec.ts
+++ b/application/src/services/channels/channels.service.spec.ts
@@ -7,7 +7,9 @@ describe('ChannelsService', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [ChannelsService],
-    }).compile();
+    })
+      .useMocker(() => ({}))
+      .compile();
 
     service = module.get<ChannelsService>(ChannelsService);
   });

--- a/application/src/services/conversations/conversations.service.spec.ts
+++ b/application/src/services/conversations/conversations.service.spec.ts
@@ -7,7 +7,9 @@ describe('ConversationsService', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [ConversationsService],
-    }).compile();
+    })
+      .useMocker(() => ({}))
+      .compile();
 
     service = module.get<ConversationsService>(ConversationsService);
   });

--- a/application/src/services/database/database.service.spec.ts
+++ b/application/src/services/database/database.service.spec.ts
@@ -1,3 +1,4 @@
+import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { DatabaseService } from './database.service';
 
@@ -7,7 +8,15 @@ describe('DatabaseService', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [DatabaseService],
-    }).compile();
+    })
+      .useMocker((token) => {
+        if (token === ConfigService) {
+          return { get: jest.fn() };
+        }
+
+        return {};
+      })
+      .compile();
 
     service = module.get<DatabaseService>(DatabaseService);
   });

--- a/application/src/services/friends/friends.service.spec.ts
+++ b/application/src/services/friends/friends.service.spec.ts
@@ -7,7 +7,9 @@ describe('FriendsService', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [FriendsService],
-    }).compile();
+    })
+      .useMocker(() => ({}))
+      .compile();
 
     service = module.get<FriendsService>(FriendsService);
   });

--- a/application/src/services/imagehandler/imagehandler.service.spec.ts
+++ b/application/src/services/imagehandler/imagehandler.service.spec.ts
@@ -7,7 +7,9 @@ describe('ImagehandlerService', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [ImagehandlerService],
-    }).compile();
+    })
+      .useMocker(() => ({}))
+      .compile();
 
     service = module.get<ImagehandlerService>(ImagehandlerService);
   });

--- a/application/src/services/invitation/invitation.service.spec.ts
+++ b/application/src/services/invitation/invitation.service.spec.ts
@@ -7,7 +7,9 @@ describe('InvitationService', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [InvitationService],
-    }).compile();
+    })
+      .useMocker(() => ({}))
+      .compile();
 
     service = module.get<InvitationService>(InvitationService);
   });

--- a/application/src/services/members/members.service.spec.ts
+++ b/application/src/services/members/members.service.spec.ts
@@ -7,7 +7,9 @@ describe('MembersService', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [MembersService],
-    }).compile();
+    })
+      .useMocker(() => ({}))
+      .compile();
 
     service = module.get<MembersService>(MembersService);
   });

--- a/application/src/services/messages/messages.service.spec.ts
+++ b/application/src/services/messages/messages.service.spec.ts
@@ -7,7 +7,9 @@ describe('MessagesService', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [MessagesService],
-    }).compile();
+    })
+      .useMocker(() => ({}))
+      .compile();
 
     service = module.get<MessagesService>(MessagesService);
   });

--- a/application/src/services/reactions/reactions.service.spec.ts
+++ b/application/src/services/reactions/reactions.service.spec.ts
@@ -7,7 +7,9 @@ describe('ReactionsService', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [ReactionsService],
-    }).compile();
+    })
+      .useMocker(() => ({}))
+      .compile();
 
     service = module.get<ReactionsService>(ReactionsService);
   });

--- a/application/src/services/roles/roles.service.spec.ts
+++ b/application/src/services/roles/roles.service.spec.ts
@@ -7,7 +7,9 @@ describe('RolesService', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [RolesService],
-    }).compile();
+    })
+      .useMocker(() => ({}))
+      .compile();
 
     service = module.get<RolesService>(RolesService);
   });

--- a/application/src/services/servers/servers.service.spec.ts
+++ b/application/src/services/servers/servers.service.spec.ts
@@ -7,7 +7,9 @@ describe('ServersService', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [ServersService],
-    }).compile();
+    })
+      .useMocker(() => ({}))
+      .compile();
 
     service = module.get<ServersService>(ServersService);
   });

--- a/application/src/services/threads/threads.service.spec.ts
+++ b/application/src/services/threads/threads.service.spec.ts
@@ -7,7 +7,9 @@ describe('ThreadsService', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [ThreadsService],
-    }).compile();
+    })
+      .useMocker(() => ({}))
+      .compile();
 
     service = module.get<ThreadsService>(ThreadsService);
   });

--- a/application/src/services/user/user.service.spec.ts
+++ b/application/src/services/user/user.service.spec.ts
@@ -7,7 +7,9 @@ describe('UserService', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [UserService],
-    }).compile();
+    })
+      .useMocker(() => ({}))
+      .compile();
 
     service = module.get<UserService>(UserService);
   });

--- a/application/src/services/validation/validation.service.spec.ts
+++ b/application/src/services/validation/validation.service.spec.ts
@@ -7,7 +7,9 @@ describe('ValidationService', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [ValidationService],
-    }).compile();
+    })
+      .useMocker(() => ({}))
+      .compile();
 
     service = module.get<ValidationService>(ValidationService);
   });

--- a/client/components/servers/channels/channel-detail.tsx
+++ b/client/components/servers/channels/channel-detail.tsx
@@ -60,7 +60,11 @@ export default function ChannelsDetail(props: Props) {
       }
 
     })
-  }, [socket]);
+    return () => {
+      socket?.off('set-message');
+      socket?.off('set-banned-members');
+    }
+  }, [router, socket, userId]);
 
   return (
     <>

--- a/client/components/servers/channels/channel-item.tsx
+++ b/client/components/servers/channels/channel-item.tsx
@@ -41,12 +41,12 @@ export default function ChannelItem({
   const reset = useCallback(() => {
     setSelectedChannel(null)
     setIsOpen(false)
-  }, [])
+  }, [setSelectedChannel])
 
   const handleClose = useCallback(() => {
     router.push(`/server/${server.id}`)
     reset()
-  }, [])
+  }, [reset, router, server.id])
 
 
   return (

--- a/client/components/servers/channels/messages.tsx
+++ b/client/components/servers/channels/messages.tsx
@@ -34,7 +34,7 @@ export default function ChannelsMessages({
       channelId,
     })
 
-  }, [])
+  }, [channelId, serverId, socket])
 
   return (
     <div className='px-2 pb-10 min-h-dvh max-h-dvh md:min-h-screen md:max-h-screen '>

--- a/client/components/servers/menu/desktop.tsx
+++ b/client/components/servers/menu/desktop.tsx
@@ -42,7 +42,7 @@ export default function ServersMenuDesktop({ server, categories }: Props) {
   const params = useParams()
   const [isLoading, setIsLoading] = useState(false)
 
-  const channels = useMemo(() => categories.filter(channel => channel.channel_type === 'text').map(c => c.channel_id).flat(), [server.id])
+  const channels = useMemo(() => categories.filter(channel => channel.channel_type === 'text').map(c => c.channel_id).flat(), [categories])
 
   const { windowWidth } = useWindowResize();
   if (windowWidth < 768) return null;

--- a/client/components/servers/threads/thread-item.tsx
+++ b/client/components/servers/threads/thread-item.tsx
@@ -33,7 +33,7 @@ export default function ThreadItem({ thread, serverId, channelId, socket, select
       serverId,
       channelId
     })
-  }, [])
+  }, [channelId, serverId, socket])
 
   const handleUpdate = async (e: FormEvent) => {
     e.preventDefault()


### PR DESCRIPTION
### Motivation

- Stabilize NestJS unit tests by providing default mocks for unresolved providers and mapping module paths for Jest.
- Prevent memory leaks and stale closures in client components by ensuring socket listeners are cleaned up and hook dependencies are correct.

### Description

- Add `moduleNameMapper` to `jest` config in `application/package.json` to map `^src/(.*)$` to `<rootDir>/$1` for tests.
- Inject `.useMocker(() => ({}))` into many `Test.createTestingModule` usages across controller and service spec files and provide a specific mock for `ConfigService` in `database.service.spec.ts` that returns `{ get: jest.fn() }`.
- Add cleanup functions to socket `useEffect` in `client/components/servers/channels/channel-detail.tsx` and register `off` for `set-message` and `set-banned-members` events, and include `router` and `userId` in the effect dependency array.
- Fix React hook dependency lists and memoization in several components (`messages.tsx`, `thread-item.tsx`, `channel-item.tsx`, `servers/menu/desktop.tsx`) to include relevant variables like `channelId`, `serverId`, `socket`, `setSelectedChannel`, `reset`, and `categories`.

### Testing

- Ran Jest unit tests with `npm test` (Jest) against the modified test suite and all tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5aabd96a083308b326ef1116c51b0)